### PR TITLE
CI for Elixir 1.10/11 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         otp: ['22.3.4']
-        elixir: ['1.11', '1.10.4', '1.9.4', '1.8.2', '1.7.4']
+        elixir: ['1.11', '1.10.4']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-elixir@v1
@@ -18,8 +18,8 @@ jobs:
           elixir-version: ${{matrix.elixir}}
       - run: mix deps.get
       - run: mix compile --warnings-as-errors
-      - run: mix credo --strict
+      # - run: mix credo --strict
       - name: "Check formatted?"
         run: mix format mix.exs "{lib,test}/**/*.{ex,exs}" --check-formatted
-        if: ${{ startsWith(matrix.elixir, '1.11') }}
+        if: ${{ startsWith(matrix.elixir, '1.XX') }}
       - run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: ['22.3.4']
+        otp: ['23.2', '22.3.4']
         elixir: ['1.11', '1.10.4']
     steps:
       - uses: actions/checkout@v2
@@ -21,5 +21,5 @@ jobs:
       # - run: mix credo --strict
       - name: "Check formatted?"
         run: mix format mix.exs "{lib,test}/**/*.{ex,exs}" --check-formatted
-        if: ${{ startsWith(matrix.elixir, '1.XX') }}
+        if: ${{ startsWith(matrix.elixir, '1.11XX') }}
       - run: mix test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Elixir ${{matrix.elixir}} (Erlang/OTP ${{matrix.otp}})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        otp: ['22.3.4']
+        elixir: ['1.11', '1.10.4', '1.9.4', '1.8.2', '1.7.4']
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+      - run: mix deps.get
+      - run: mix compile --warnings-as-errors
+      - run: mix credo --strict
+      - name: "Check formatted?"
+        run: mix format mix.exs "{lib,test}/**/*.{ex,exs}" --check-formatted
+        if: ${{ startsWith(matrix.elixir, '1.11') }}
+      - run: mix test

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Pathex.MixProject do
     [
       app:             :pathex,
       version:         @version,
-      elixir:          "~> 1.7",
+      elixir:          "~> 1.10",
       start_permanent: Mix.env() == :prod,
       description:     description(),
       package:         package(),

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Pathex.MixProject do
     [
       app:             :pathex,
       version:         @version,
-      elixir:          "~> 1.10",
+      elixir:          "~> 1.7",
       start_permanent: Mix.env() == :prod,
       description:     description(),
       package:         package(),

--- a/test/pathex_test.exs
+++ b/test/pathex_test.exs
@@ -253,7 +253,6 @@ defmodule PathexTest do
   end
 
   test "tricky path" do
-    x = :x
     p = path {:x, [], nil}
     assert {:ok, 1} = view(%{{:x, [], nil} => 1, :x => 2}, p)
   end

--- a/test/pathex_test.exs
+++ b/test/pathex_test.exs
@@ -7,6 +7,8 @@ defmodule PathexTest do
   require Pathex
   import Pathex
 
+  @compile :nowarn_unused_vars
+
   test "view: naive sigil path: binary" do
     path = ~P["hey"]naive
     assert {:ok, true} = view %{"hey" => true}, path
@@ -253,6 +255,8 @@ defmodule PathexTest do
   end
 
   test "tricky path" do
+    # This one is necessary for testing macro hygiene
+    x = :x
     p = path {:x, [], nil}
     assert {:ok, 1} = view(%{{:x, [], nil} => 1, :x => 2}, p)
   end


### PR DESCRIPTION
I want to start using this library - would be great to have CI! This uses github actions

This PR runs CI for the latest Elixir and compatible OTP versions. We can go back to earlier Elixir versions that are still supported for security patches - it just requires some minor reformatting of the last line of some of doctests - the last line needs to be expected result

Credo is disabled - I have a small separate PR for this incoming

Formatting check is currently disabled - I don't want to reformat your project - but the option is there