### PR TITLE
Update note to use "pin" instead of "capture"

### DIFF
--- a/guides/tutorials/basics.md
+++ b/guides/tutorials/basics.md
@@ -21,7 +21,7 @@ p = path :x / :y
 This path specifies a way to get (or set, or delete or whatever) value `1` from `%{x: %{y: 1}}`
 
 > Note:
-> You **don't** have to capture used variables
+> You **don't** have to pin variables used in paths
 >
 > ```elixir
 > x = 1


### PR DESCRIPTION
I think this meant to say "pin" because variables are "pinned" (`^`) and functions use the "capture" operator (`&`).